### PR TITLE
include speakers on main page

### DIFF
--- a/_includes/speaker-gallery.html
+++ b/_includes/speaker-gallery.html
@@ -1,0 +1,183 @@
+<div class="columns is-multiline">
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/timnit_gebru.jpg" alt="Dr. Timnit Gebru">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                26th Oct
+              </span>
+            </div>
+        </div>
+        <footer class="card-footer card-footer-padding:0rem">
+            <a class="card-footer-item" href="speakers#timnit_gebru">
+              Dr. Timnit Gebru
+            </a>
+        </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/yoshua_bengio.jpg" alt="Prof. Yoshua Bengio">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                3rd Nov
+              </span>
+            </div>
+        </div>
+        <footer class="card-footer">
+            <a class="card-footer-item" href="speakers#yoshua_bengio">
+              Prof. Yoshua Bengio
+            </a>
+        </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/max_welling.jpg" alt="Prof. Max Welling">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                14th Nov
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#max_welling">
+            Prof. Max Welling
+          </a>
+      </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/regina_barzilay.jpg" alt="Prof. Regina Barzilay">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                21st Nov
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#regina_barzilay">
+            Prof. Regina Barzilay
+          </a>
+      </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/david_rolnick.jpg" alt="Prof. David Rolnick">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                24th Nov
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#david_rolnick">
+            Prof. David Rolnick
+          </a>
+      </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/anna_goldenberg.jpg" alt="Prof. Anna Goldenberg">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                8th Dec (in person)
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#anna_goldenberg">
+            Prof. Anna Goldenberg
+          </a>
+      </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/michael_bronstein.jpg" alt="Prof. Michael Bronstein">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                TBA
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#michael_bronstein">
+            Prof. Michael Bronstein
+          </a>
+      </footer>
+    </div>
+  </div>
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/sara_beery.jpg" alt="Dr. Sara Beery">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                5th Dec
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#sara_beery">
+            Dr. Sara Beery
+          </a>
+      </footer>
+    </div>
+  </div>
+
+
+  <div class="column is-one-fifth-desktop is-half-tablet">
+    <div class="card">
+        <div class="card-image">
+            <figure class="image is-square">
+              <img src="assets/img/speakers/alexei_efros.jpg" alt="Prof. Alexei Efros">
+            </figure>
+            <div class="card-content is-overlay is-clipped">
+              <span class="tag is-primary">
+                TBA
+              </span>
+            </div>
+        </div>
+      <footer class="card-footer">
+          <a class="card-footer-item" href="speakers#alexei_efros">
+            Prof. Alexei Efros
+          </a>
+      </footer>
+    </div>
+  </div>
+
+</div>

--- a/index.md
+++ b/index.md
@@ -18,6 +18,10 @@ Participation is free and everyone is welcome to donate according to their possi
 
 ---
 
+# Our Speakers
+{% include speaker-gallery.html %}
+
+---
 # Why
 
 Russian invasion of Ukraine has caused a grave humanitarian crisis destroying civilian infrastructure and forcing millions of people to leave their homes seeking safety and protection. According to [UNHCR](https://www.unhcr.org/ukraine-emergency.html), more than 7.2 million of Ukrainians had to flee from the war abroad and more than 6.9 million were displaced within the country since 24 February 2022. Many of them are still located close to the conflict zones and remain in need of food, hygiene, warm clothes and shelters. Together with infrastructure, medicine supply chains were broken and these days Ukrainian hospitals are lacking not only specialized medicines and machines but even essential basics, such as toilet paper and medical gloves.


### PR DESCRIPTION
Add speakers on the main page. Bulma-theme-styled. 

Necessary improvements: making a for loop instead of adding each speaker individually (I am sorry about that. This was quicker for me because I still need to take a look on how Alex does this usually - I can adapt that later when I have a bite more time). 

Very necessary: removing the space between the footer and the image. I have no idea how to that and I tried to fix it in several different ways.

I think it still looks nice / better than without speakers.