### PR TITLE
Made the join button controlled via variables in /data/settings.yml

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,0 +1,3 @@
+talk:
+    isLive: False
+    speaker: Hannah Kerner

--- a/_includes/join-button.html
+++ b/_includes/join-button.html
@@ -5,7 +5,8 @@
 			<button
 				class="button is-responsive is-link is-large is-rounded is-fullwidth is-light is-primary is-outlined"
 			>
-				Join Hannah Kerner's talk here and right now!
+				Join {{site.data.settings.talk.speaker}}'s talk here and right
+				now!
 			</button>
 		</a>
 	</div>

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ toc: false
 
 {% include registration-button.html %}
 
-<!-- {% include join-button.html %} -->
+{% if site.data.settings.talk.isLive %}{% include join-button.html %}{% endif %}
 
 # What
 


### PR DESCRIPTION
I simplified the process of making the join button visible by centralizing the controls of the button. It is now possible to change the name of the speaker and specify whether the button should be visible.

Here is how it works:
- The variable `speaker` takes a string as a value and uses it in the join button as the name of the speaker.
- The variable `isLive` is a boolean. If `isLive==True`, then a talk is live and the join button is visible. Else, it is hidden.

I decided that these variables that are not part of the base settings of the website should be placed in the `/data/settings.yml` file to avoid bloating the `/_config.yml` file. This may easily be changed if needed.